### PR TITLE
Docker cant import specified realm

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
       KEYCLOAK_PASSWORD: password
       # Uncomment the line below if you want to specify JDBC parameters. The parameter below is just an example, and it shouldn't be used in production without knowledge. It is highly recommended that you read the PostgreSQL JDBC driver documentation in order to use it.
       #JDBC_PARAMS: "ssl=true"
-      KEYCLOAK_IMPORT: /tmp/dinivas-realm.json
+      KEYCLOAK_IMPORT: /tmp/dinivas-realm.json -Dkeycloak.profile.feature.upload_scripts=enabled
     ports:
       - 8085:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       KEYCLOAK_PASSWORD: password
       # Uncomment the line below if you want to specify JDBC parameters. The parameter below is just an example, and it shouldn't be used in production without knowledge. It is highly recommended that you read the PostgreSQL JDBC driver documentation in order to use it.
       #JDBC_PARAMS: "ssl=true"
-      KEYCLOAK_IMPORT: /tmp/dinivas-realm.json
+      KEYCLOAK_IMPORT: /tmp/dinivas-realm.json -Dkeycloak.profile.feature.upload_scripts=enabled
     ports:
       - 8080:8080
     volumes:


### PR DESCRIPTION
There is an issue with the import of a specified Realm for the latest version 9.0.0 of the keycloak image, so you have to add the option [Dkeycloak.profile.feature.upload_scripts=enabled].
look at the same issue
https://keycloak.discourse.group/t/cant-import-realm-using-docker-image/259