### PR TITLE
Auto creation of the workspace directory and typeorm version update to work with postgres 12

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -6,7 +6,7 @@ RUN apk update && apk add nginx && \
     rm -rf /var/cache/apk/* &&  mkdir -p /run/nginx/ && \
     chown -R nginx:www-data /var/lib/nginx /run/nginx/
 
-RUN npm install -g nodemon
+RUN npm config set unsafe-perm true && npm install -g nodemon
 
 ADD package.json /tmp/package.json
 ADD package-lock.json /tmp/package-lock.json

--- a/apps/api/src/app/core/config/config.service.ts
+++ b/apps/api/src/app/core/config/config.service.ts
@@ -9,6 +9,13 @@ export const config: IConfig = require('config');
 console.log('NODE_CONFIG_DIR: ' + config.util.getEnv('NODE_CONFIG_DIR'));
 const path = require('path');
 
+const fileSystem = require('fs');
+const homeDirectory = require('os').homedir();
+const dinivasWorkspaceDirectory = homeDirectory + '/.dinivas/workspace';
+if (!fileSystem.existsSync(dinivasWorkspaceDirectory)){
+  fileSystem.mkdirSync(dinivasWorkspaceDirectory, { recursive: true });
+}
+
 @Injectable()
 export class ConfigService {
   private readonly logger = new Logger(ConfigService.name);
@@ -36,7 +43,7 @@ export class ConfigService {
   }
 
   getWorkspaceRootPath(): string {
-    return this.get('workspace.root-path');
+    return dinivasWorkspaceDirectory;
   }
 
   private checkRequiredPath() {

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,5 @@
 dinivas:
   production: false
-  workspace:
-    root-path: '/Users/chidi/.dinivas/workspace'
   orm:
     config:
       type: postgres

--- a/config/serveo.yml
+++ b/config/serveo.yml
@@ -1,7 +1,5 @@
 dinivas:
   production: false
-  workspace:
-    root-path: '/Users/chidi/.dinivas/workspace'
   terraform:
     min_required_version: '0.12.2'
     debug_command_outputs: false

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "simple-git": "^1.121.0",
     "strip-ansi": "^5.2.0",
     "swagger-ui-express": "^4.0.6",
-    "typeorm": "^0.2.18",
+    "typeorm": "^0.2.21",
     "yaml": "^1.6.0",
     "zone.js": "^0.9.1"
   },


### PR DESCRIPTION
The server API start command generate 2 errors that have been fixed in this pull request.
The first error is that the workspace path is defined manually and needs to be altered in the config files and then created accordingly. In order to prevent such behaviour, I've added the auto creation of the workspace folders and removed unnecessary configuration.
The second error is that the typeorm version needs to be upgraded so that it could work with postgres 12.